### PR TITLE
Enable use of client/server config with ZeroMQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ The following FMI parameters can be set.
 Either `sender` or `receiver` have to be set to _true_.
 Otherwise, the FMU will return with an error.
 
-| Type    | Parameter  | Default     | Description                                |
-|---------|------------|-------------|--------------------------------------------|
-| Boolean | `sender`   | _true_      | Set if Proxy shall send data via TCP/IP    |
-| Boolean | `receiver` | _false_     | Set if Proxy shall receive data via TCP/IP |
-| String  | `ip`       | _127.0.0.1_ | IP address of TCP connection               |
-| String  | `port`     | _3456_      | Port of TCP connection                     |
+| Type    | Parameter  | Default     | Description                                                                                                                                                               |
+|---------|------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Boolean | `sender`   | _true_      | Set if Proxy shall send data via TCP/IP                                                                                                                                   |
+| Boolean | `receiver` | _false_     | Set if Proxy shall receive data via TCP/IP                                                                                                                                |
+| Boolean | `pushpull` | _false_     | If true, use [Push/Pull](https://learning-0mq-with-pyzmq.readthedocs.io/en/latest/pyzmq/patterns/pushpull.html) ZeroMQ configuration, if false, use [Client/Server](https://learning-0mq-with-pyzmq.readthedocs.io/en/latest/pyzmq/patterns/client_server.html) config. |
+| String  | `ip`       | _127.0.0.1_ | IP address of TCP connection                                                                                                                                              |
+| String  | `port`     | _3456_      | Port of TCP connection                                                                                                                                                    |
 
 ## Interface
 

--- a/src/OSMP.h
+++ b/src/OSMP.h
@@ -42,7 +42,8 @@
 #define FMI_BOOLEAN_VALID_IDX 0
 #define FMI_BOOLEAN_SENDER_IDX 1
 #define FMI_BOOLEAN_RECEIVER_IDX 2
-#define FMI_BOOLEAN_LAST_IDX FMI_BOOLEAN_RECEIVER_IDX
+#define FMI_BOOLEAN_PUSHPULL_IDX 3
+#define FMI_BOOLEAN_LAST_IDX FMI_BOOLEAN_PUSHPULL_IDX
 #define FMI_BOOLEAN_VARS (FMI_BOOLEAN_LAST_IDX + 1)
 
 /* Integer Variables */
@@ -233,6 +234,8 @@ class OSMP
     void SetFmiReceiver(fmi2Boolean value) { boolean_vars_[FMI_BOOLEAN_RECEIVER_IDX] = value; }
     fmi2Boolean FmiSender() { return boolean_vars_[FMI_BOOLEAN_SENDER_IDX]; }
     void SetFmiSender(fmi2Boolean value) { boolean_vars_[FMI_BOOLEAN_SENDER_IDX] = value; }
+    fmi2Boolean FmiPushPull() { return boolean_vars_[FMI_BOOLEAN_PUSHPULL_IDX]; }
+    void SetFmiPushPull(fmi2Boolean value) { boolean_vars_[FMI_BOOLEAN_PUSHPULL_IDX] = value; }
     string FmiIp() { return string_vars_[FMI_STRING_IP_IDX]; }
     void SetFmiIp(fmi2String value) { string_vars_[FMI_STRING_IP_IDX] = value; }
     string FmiPort() { return string_vars_[FMI_STRING_PORT_IDX]; }

--- a/src/modelDescription.in.xml
+++ b/src/modelDescription.in.xml
@@ -51,6 +51,9 @@
     <ScalarVariable name="receiver" valueReference="2" causality="parameter" variability="fixed" initial="exact">
       <Boolean start="false"/>
     </ScalarVariable>
+    <ScalarVariable name="pushpull" valueReference="3" causality="parameter" variability="fixed" initial="exact">
+      <Boolean start="true"/>
+    </ScalarVariable>
     <ScalarVariable name="ip" valueReference="0" causality="parameter" variability="fixed" initial="exact">
       <String start="127.0.0.1"/>
     </ScalarVariable>


### PR DESCRIPTION
**Add a description**
Currently, the proxy uses the Push/Pull messaging pattern of ZeroMQ. In this PR, the Client/Server pattern was additionally implemented. The user can choose with an FMI parameter, which config he wants to use. With the Client/Server pattern, the sender waits for the receiver to be ready before sending the message.

**Take this checklist as orientation for yourself, if this PR is ready for Maintainer Review**
- [x] My suggestion follows the [governance rules](https://github.com/openMSL/governance-and-documentation).
- [x] All commits of this PR are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [ ] My changes generate no errors when passing CI tests. 
- [x] I updated all documentation (readmes incl. figures) according to my changes.
- [x] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.
